### PR TITLE
Added a client interface to facilitate mocking

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,14 @@ import (
 	"time"
 )
 
+var _ APNSClient = &Client{}
+
+// APNSClient is an APNS client.
+type APNSClient interface {
+	ConnectAndWrite(resp *PushNotificationResponse, payload []byte) (err error)
+	Send(pn *PushNotification) (resp *PushNotificationResponse)
+}
+
 // Client contains the fields necessary to communicate
 // with Apple, such as the gateway to use and your
 // certificate contents.
@@ -100,7 +108,7 @@ func (client *Client) ConnectAndWrite(resp *PushNotificationResponse, payload []
 	gatewayParts := strings.Split(client.Gateway, ":")
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		ServerName: gatewayParts[0],
+		ServerName:   gatewayParts[0],
 	}
 
 	conn, err := net.Dial("tcp", client.Gateway)

--- a/client_mock.go
+++ b/client_mock.go
@@ -1,0 +1,21 @@
+package apns
+
+import "github.com/stretchr/testify/mock"
+
+type MockClient struct {
+	mock.Mock
+}
+
+func (m *MockClient) ConnectAndWrite(resp *PushNotificationResponse, payload []byte) (err error) {
+	return m.Called(resp, payload).Error(0)
+}
+
+func (m *MockClient) Send(pn *PushNotification) (resp *PushNotificationResponse) {
+	r := m.Called(pn).Get(0)
+	if r != nil {
+		if r, ok := r.(*PushNotificationResponse); ok {
+			return r
+		}
+	}
+	return nil
+}

--- a/client_mock_test.go
+++ b/client_mock_test.go
@@ -1,0 +1,24 @@
+package apns
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockClientConnectAndWrite(t *testing.T) {
+	m := &MockClient{}
+	m.On("ConnectAndWrite", (*PushNotificationResponse)(nil), []byte(nil)).Return(nil)
+	assert.Nil(t, m.ConnectAndWrite(nil, nil))
+	m.On("ConnectAndWrite", &PushNotificationResponse{}, []byte{}).Return(errors.New("test"))
+	assert.Equal(t, errors.New("test"), m.ConnectAndWrite(&PushNotificationResponse{}, []byte{}))
+}
+
+func TestMockClientSend(t *testing.T) {
+	m := &MockClient{}
+	m.On("Send", (*PushNotification)(nil)).Return(nil)
+	assert.Nil(t, m.Send(nil))
+	m.On("Send", &PushNotification{}).Return(&PushNotificationResponse{})
+	assert.Equal(t, &PushNotificationResponse{}, m.Send(&PushNotification{}))
+}

--- a/feedback.go
+++ b/feedback.go
@@ -57,7 +57,7 @@ func (client *Client) ListenForFeedback() (err error) {
 	gatewayParts := strings.Split(client.Gateway, ":")
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		ServerName: gatewayParts[0],
+		ServerName:   gatewayParts[0],
 	}
 
 	conn, err := net.Dial("tcp", client.Gateway)


### PR DESCRIPTION
Makes it easier for testing where you don't want tests to actually connect to APNS, but you can observe how other components use the client.